### PR TITLE
Django4 compatibility

### DIFF
--- a/django_ajax/decorators.py
+++ b/django_ajax/decorators.py
@@ -10,6 +10,10 @@ from django.http import HttpResponseBadRequest
 from django_ajax.shortcuts import render_to_json
 
 
+def is_ajax(request):
+    return request.META.get("HTTP_X_REQUESTED_WITH") == "XMLHttpRequest"
+
+
 def ajax(function=None, mandatory=True, **ajax_kwargs):
     """
     Decorator who guesses the user response type and translates to a serialized
@@ -58,10 +62,10 @@ def ajax(function=None, mandatory=True, **ajax_kwargs):
     def decorator(func):
         @wraps(func, assigned=WRAPPER_ASSIGNMENTS)
         def inner(request, *args, **kwargs):
-            if mandatory and not request.is_ajax():
+            if mandatory and not is_ajax(request):
                 return HttpResponseBadRequest()
 
-            if request.is_ajax():
+            if is_ajax(request):
                 # return json response
                 try:
                     return render_to_json(func(request, *args, **kwargs), request, **ajax_kwargs)

--- a/django_ajax/encoder.py
+++ b/django_ajax/encoder.py
@@ -28,7 +28,7 @@ class LazyJSONEncoderMixin(object):
         elif issubclass(type(obj), HttpResponse):
             return obj.content
         elif issubclass(type(obj), Exception) or isinstance(obj, bytes):
-            return force_text(obj)
+            return force_str(obj)
 
         # this handles querysets and other iterable types
         try:
@@ -40,7 +40,7 @@ class LazyJSONEncoderMixin(object):
 
         # this handlers Models
         if isinstance(obj.__class__, ModelBase):
-            return force_text(obj)
+            return force_str(obj)
 
         if isinstance(obj, Decimal):
             return float(obj)


### PR DESCRIPTION
Django does not promise to provide "request.is_ajax()", as it seems to have been jQuery specific.

Check needs to be done different, now.